### PR TITLE
Bump controlsfx

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ dependencies {
 //make grapes work
 		compile group: 'org.apache.ivy', name:'ivy', version:'2.2.0'
 			
-	compile group: 'org.controlsfx', name: 'controlsfx', version: '8.0.6'
+	compile group: 'org.controlsfx', name: 'controlsfx', version: '8.40.14'
 	compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
 	compile group: 'commons-codec', name: 'commons-codec', version: '1.7'
 	compile 'org.kohsuke.stapler:stapler:1.237'


### PR DESCRIPTION
The issue I am having with not being able to use certain ControlsFX features is most probably caused by the kernel using a very old version of ControlsFX. Why does the kernel, an either completely headless or cli-based application, need ControlsFX in the first place?

I am currently unable to test the build myself, so someone else will have to run a build (or maybe CI will catch any problems).