### PR TITLE
update CI to use java21

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       run: pwd; ls -la        
 
     - name: Pull a JavaFX JDK
-      run: wget http://static.azul.com/zulu/bin/zulu8.33.0.1-ca-fx-jdk8.0.192-linux_x64.tar.gz
+      run: wget https://cdn.azul.com/zulu/bin/zulu21.46.19-ca-fx-jdk21.0.9-linux_x64.tar.gz
 
     - name: After JDK download, list directory contnts
       run: pwd; ls -la
@@ -38,8 +38,8 @@ jobs:
     - name: Set Java
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
-        jdkFile: ./zulu8.33.0.1-ca-fx-jdk8.0.192-linux_x64.tar.gz
+        java-version: 21
+        jdkFile: zulu21.46.19-ca-fx-jdk21.0.9-linux_x64.tar.gz
     - name: Get the version
       id: get_version
       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}   

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Set Java
       uses: actions/setup-java@v1
       with:
-        java-version: 21
+        java-version: 
         jdkFile: zulu21.46.19-ca-fx-jdk21.0.9-linux_x64.tar.gz
     - name: Get the version
       id: get_version
@@ -49,9 +49,11 @@ jobs:
          echo $'app.name=BowlerScriptKernel' > src/main/resources/com/neuronrobotics/bowlerkernel/build.properties 
          echo "app.version=${{ steps.get_version.outputs.VERSION  }}" >> src/main/resources/com/neuronrobotics/bowlerkernel/build.properties
 
-                
+    - name: test with Gradle 
+      run: ./gradlew test
+                      
     - name: Build with Gradle 
-      run: ./gradlew test shadowJar
+      run: ./gradlew shadowJar
       
     - name: release
       uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Set Java
       uses: actions/setup-java@v1
       with:
-        java-version: 
+        java-version: 21
         jdkFile: zulu21.46.19-ca-fx-jdk21.0.9-linux_x64.tar.gz
     - name: Get the version
       id: get_version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
 
                 
     - name: Build with Gradle 
-      run: ./gradlew shadowJar
+      run: ./gradlew test shadowJar
       
     - name: release
       uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       
     - name: start xvfb
       run:
-        Xvfb :99 &
+        Xvfb :0 &
 
     - name: initialize the X11 DISPLAY variable
       run:
@@ -49,8 +49,11 @@ jobs:
          echo $'app.name=BowlerScriptKernel' > src/main/resources/com/neuronrobotics/bowlerkernel/build.properties 
          echo "app.version=${{ steps.get_version.outputs.VERSION  }}" >> src/main/resources/com/neuronrobotics/bowlerkernel/build.properties
 
-    - name: test with Gradle 
-      run: ./gradlew test
+    - name: initialize the X11 DISPLAY variable
+      run:
+        export DISPLAY=:0
+    - name: Build/Test with Gradle 
+      run: xvfb-run -s '-screen 0 1024x768x24' ./gradlew test 
                       
     - name: Build with Gradle 
       run: ./gradlew shadowJar

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -52,7 +52,7 @@ jobs:
         
     - name: Build/Test with Gradle 
       run: ./gradlew clean test 
-    - name: Build/Test with Gradle 
+    - name: Shadow Jar 
       run: ./gradlew  shadowJar         
     - name: Test Bezier 
       run:  xvfb-run -s '-screen 0 1024x768x24' java -Dprism.order=sw -Dprism.verbose=true -jar build/libs/bowler-kernel.jar -g https://gist.github.com/4aeeaa49bd3a807eed8f8ff3dea84c48.git  BezierEditorDemo.groovy 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -51,8 +51,9 @@ jobs:
         jdkFile: ./zulu21.46.19-ca-fx-jdk21.0.9-linux_x64.tar.gz
         
     - name: Build/Test with Gradle 
-      run: ./gradlew clean test shadowJar
-         
+      run: ./gradlew clean test 
+    - name: Build/Test with Gradle 
+      run: ./gradlew  shadowJar         
     - name: Test Bezier 
       run:  xvfb-run -s '-screen 0 1024x768x24' java -Dprism.order=sw -Dprism.verbose=true -jar build/libs/bowler-kernel.jar -g https://gist.github.com/4aeeaa49bd3a807eed8f8ff3dea84c48.git  BezierEditorDemo.groovy 
     - name: start xvfb

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -34,9 +34,7 @@ jobs:
       run: |
           sudo apt update
           sudo apt install libgtk2.0-0
-    - name: initialize the X11 DISPLAY variable
-      run:
-        export DISPLAY=:0
+
           
     - name: Pull a JavaFX JDK
       run: wget https://cdn.azul.com/zulu/bin/zulu21.46.19-ca-fx-jdk21.0.9-linux_x64.tar.gz
@@ -51,6 +49,9 @@ jobs:
         jdkFile: ./zulu21.46.19-ca-fx-jdk21.0.9-linux_x64.tar.gz
     - name: Shadow Jar 
       run: ./gradlew  shadowJar        
+    - name: initialize the X11 DISPLAY variable
+      run:
+        export DISPLAY=:0
     - name: Build/Test with Gradle 
       run: xvfb-run -s '-screen 0 1024x768x24' ./gradlew test 
         

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -50,7 +50,6 @@ jobs:
         java-version: 21
         jdkFile: ./zulu21.46.19-ca-fx-jdk21.0.9-linux_x64.tar.gz
         
-     
     - name: Build with Gradle 
       run: ./gradlew shadowJar
       

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -49,7 +49,7 @@ jobs:
       with:
         java-version: 21
         jdkFile: ./zulu21.46.19-ca-fx-jdk21.0.9-linux_x64.tar.gz
-     - name: Shadow Jar 
+    - name: Shadow Jar 
       run: ./gradlew  shadowJar        
     - name: Build/Test with Gradle 
       run: ./gradlew test 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -46,7 +46,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 21
-        jdkFile: ./zulu21.46.19-ca-fx-jdk21.0.9-linux_x64.tar.gz
+        jdkFile: zulu21.46.19-ca-fx-jdk21.0.9-linux_x64.tar.gz
     - name: Shadow Jar 
       run: ./gradlew  shadowJar        
     - name: initialize the X11 DISPLAY variable

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -50,12 +50,8 @@ jobs:
         java-version: 21
         jdkFile: ./zulu21.46.19-ca-fx-jdk21.0.9-linux_x64.tar.gz
         
-    - name: Build with Gradle 
-      run: ./gradlew shadowJar
-      
-    - name: Test with Gradle 
-      run: xvfb-run -s '-screen 0 1024x768x24' ./gradlew clean test
-
+    - name: Build/Test with Gradle 
+      run: ./gradlew clean test shadowJar
          
     - name: Test Bezier 
       run:  xvfb-run -s '-screen 0 1024x768x24' java -Dprism.order=sw -Dprism.verbose=true -jar build/libs/bowler-kernel.jar -g https://gist.github.com/4aeeaa49bd3a807eed8f8ff3dea84c48.git  BezierEditorDemo.groovy 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -49,11 +49,11 @@ jobs:
       with:
         java-version: 21
         jdkFile: ./zulu21.46.19-ca-fx-jdk21.0.9-linux_x64.tar.gz
-        
+     - name: Shadow Jar 
+      run: ./gradlew  shadowJar        
     - name: Build/Test with Gradle 
-      run: ./gradlew clean test 
-    - name: Shadow Jar 
-      run: ./gradlew  shadowJar         
+      run: ./gradlew test 
+        
     - name: Test Bezier 
       run:  xvfb-run -s '-screen 0 1024x768x24' java -Dprism.order=sw -Dprism.verbose=true -jar build/libs/bowler-kernel.jar -g https://gist.github.com/4aeeaa49bd3a807eed8f8ff3dea84c48.git  BezierEditorDemo.groovy 
     - name: start xvfb

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -39,7 +39,7 @@ jobs:
         export DISPLAY=:0
           
     - name: Pull a JavaFX JDK
-      run: wget http://static.azul.com/zulu/bin/zulu8.78.0.19-ca-fx-jdk8.0.412-linux_x64.tar.gz
+      run: wget https://cdn.azul.com/zulu/bin/zulu21.46.19-ca-fx-jdk21.0.9-linux_x64.tar.gz
 
     - name: After JDK download, list directory contnts
       run: pwd; ls -la
@@ -47,8 +47,8 @@ jobs:
     - name: Set Java
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
-        jdkFile: ./zulu8.78.0.19-ca-fx-jdk8.0.412-linux_x64.tar.gz
+        java-version: 21
+        jdkFile: ./zulu21.46.19-ca-fx-jdk21.0.9-linux_x64.tar.gz
         
      
     - name: Build with Gradle 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Shadow Jar 
       run: ./gradlew  shadowJar        
     - name: Build/Test with Gradle 
-      run: ./gradlew test 
+      run: xvfb-run -s '-screen 0 1024x768x24' ./gradlew test 
         
     - name: Test Bezier 
       run:  xvfb-run -s '-screen 0 1024x768x24' java -Dprism.order=sw -Dprism.verbose=true -jar build/libs/bowler-kernel.jar -g https://gist.github.com/4aeeaa49bd3a807eed8f8ff3dea84c48.git  BezierEditorDemo.groovy 

--- a/build.gradle
+++ b/build.gradle
@@ -333,7 +333,22 @@ artifacts {
 	archives javadocJar, sourcesJar, jar
 }
 
+//test {
+//    testLogging.showExceptions = true
+//    testLogging.showCauses = true
+//}
 test {
-    testLogging.showExceptions = true
-    testLogging.showCauses = true
+	testLogging {
+		// Show which test is running
+		events "passed", "skipped", "failed", "standardOut", "standardError"
+		
+		// Show standard out and error
+		showStandardStreams = true
+		
+		// Optional: show more details
+		exceptionFormat = "full"
+		showExceptions = true
+		showCauses = true
+		showStackTraces = true
+	}
 }

--- a/src/main/java/com/neuronrobotics/bowlerstudio/BowlerKernel.java
+++ b/src/main/java/com/neuronrobotics/bowlerstudio/BowlerKernel.java
@@ -124,6 +124,12 @@ public class BowlerKernel {
 	}
 
 	private static void fail() {
+		try {
+			Thread.sleep(1000);
+		} catch (InterruptedException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
 		com.neuronrobotics.sdk.common.Log.error(
 				"Usage: \r\njava -jar BowlerScriptKernel.jar -s <file 1> .. <file n> # This will load one script after the next ");
 		com.neuronrobotics.sdk.common.Log.error(
@@ -452,7 +458,9 @@ public class BowlerKernel {
 		processUIOpening(ret);
 		if (baseWorkspaceFile != null)
 			com.neuronrobotics.sdk.common.Log.debug("Processing file in directory: \n   " + baseWorkspaceFile.getAbsolutePath()+" \nto "+target.getAbsolutePath());
-
+		File baseDirForTarget = new File(target.getAbsolutePath() + "/manufacturing/");
+		if(!baseDirForTarget.exists())
+			baseDirForTarget.mkdirs();
 		if (baseWorkspaceFile != null) {
 
 			File baseDirForFiles = new File(baseWorkspaceFile.getAbsolutePath() + "/manufacturing/");
@@ -463,7 +471,7 @@ public class BowlerKernel {
 				if (bomCSV.exists()) {
 
 					File file = new File(
-							target.getAbsolutePath() + "/" + VitaminBomManager.getManufacturingBomCsv());
+							baseDirForTarget.getAbsolutePath() + "/" + VitaminBomManager.getManufacturingBomCsv());
 //					if (file.exists())
 //						file.delete();
 					try {
@@ -477,7 +485,7 @@ public class BowlerKernel {
 						baseWorkspaceFile.getAbsolutePath() + "/" + VitaminBomManager.getManufacturingBomJson());
 				if (bom.exists()) {
 					File file = new File(
-							target.getAbsolutePath() + "/" + VitaminBomManager.getManufacturingBomJson());
+							baseDirForTarget.getAbsolutePath() + "/" + VitaminBomManager.getManufacturingBomJson());
 //					if (file.exists())
 //						file.delete();
 					try {
@@ -487,8 +495,6 @@ public class BowlerKernel {
 						Log.error(e);
 					}
 				}
-			} else {
-				baseDirForFiles.mkdirs();
 			}
 		}
 		ArrayList<CSG> csgBits = new ArrayList<>();
@@ -502,7 +508,7 @@ public class BowlerKernel {
 			else {
 				com.neuronrobotics.sdk.common.Log.error("Exporting files without print bed");
 			}
-			new CadFileExporter().generateManufacturingParts(csgBits, target);
+			new CadFileExporter().generateManufacturingParts(csgBits, baseDirForTarget);
 		} catch (Throwable t) {
 			Log.error(t);
 			fail();
@@ -614,6 +620,12 @@ public class BowlerKernel {
 				@Override
 				public void highlightException(File fileEngineRunByName, Throwable ex) {
 					Log.error(ex);
+					try {
+						Thread.sleep(1000);
+					} catch (InterruptedException e) {
+						// TODO Auto-generated catch block
+						e.printStackTrace();
+					}
 					fail();
 				}
 

--- a/src/main/java/com/neuronrobotics/bowlerstudio/BowlerKernel.java
+++ b/src/main/java/com/neuronrobotics/bowlerstudio/BowlerKernel.java
@@ -200,7 +200,7 @@ public class BowlerKernel {
 		}
 
 		Object ret = null;
-		File baseWorkspaceFile = null;
+		File baseWorkspaceFile = new File(".").getAbsoluteFile();
 		if (gitRun && gitRepo != null) {
 			String url = null;
 
@@ -227,7 +227,7 @@ public class BowlerKernel {
 					url = gitRepo;
 					baseWorkspaceFile = ScriptingEngine.getRepositoryCloneDirectory(url);
 
-					processReturnedObjectsStart(ret, baseWorkspaceFile);
+					processReturnedObjectsStart(ret, baseWorkspaceFile,new File(".").getAbsoluteFile());
 				} catch (Throwable e) {
 					Log.error(e);
 					fail();
@@ -280,7 +280,7 @@ public class BowlerKernel {
 			}
 		}
 		if (startLoadingScripts) {
-			processReturnedObjectsStart(ret, baseWorkspaceFile);
+			processReturnedObjectsStart(ret, baseWorkspaceFile,new File(".").getAbsoluteFile());
 			startLoadingScripts = false;
 			finish(startTime);
 			return;
@@ -301,7 +301,7 @@ public class BowlerKernel {
 			}
 		}
 		if (startLoadingScripts) {
-			processReturnedObjectsStart(ret, new File("."));
+			processReturnedObjectsStart(ret, new File(".").getAbsoluteFile(),new File(".").getAbsoluteFile());
 			finish(startTime);
 			return;
 		}
@@ -403,7 +403,7 @@ public class BowlerKernel {
 					if (ret != null) {
 						com.neuronrobotics.sdk.common.Log.error(ret);
 					}
-					processReturnedObjectsStart(ret, null);
+					processReturnedObjectsStart(ret, null,new File(".").getAbsoluteFile());
 				} catch (Throwable e) {
 					Log.error(e);
 				} 
@@ -448,11 +448,10 @@ public class BowlerKernel {
 		System.exit(0);
 	}
 
-	public static void processReturnedObjectsStart(Object ret, File baseWorkspaceFile) {
-		CSG.setPreventNonManifoldTriangles(true);
+	public static void processReturnedObjectsStart(Object ret, File baseWorkspaceFile, File target) {
 		processUIOpening(ret);
 		if (baseWorkspaceFile != null)
-			com.neuronrobotics.sdk.common.Log.debug("Processing file in directory " + baseWorkspaceFile.getAbsolutePath());
+			com.neuronrobotics.sdk.common.Log.debug("Processing file in directory: \n   " + baseWorkspaceFile.getAbsolutePath()+" \nto "+target.getAbsolutePath());
 
 		if (baseWorkspaceFile != null) {
 
@@ -464,7 +463,7 @@ public class BowlerKernel {
 				if (bomCSV.exists()) {
 
 					File file = new File(
-							baseWorkspaceFile.getAbsolutePath() + "/" + VitaminBomManager.getManufacturingBomCsv());
+							target.getAbsolutePath() + "/" + VitaminBomManager.getManufacturingBomCsv());
 //					if (file.exists())
 //						file.delete();
 					try {
@@ -478,7 +477,7 @@ public class BowlerKernel {
 						baseWorkspaceFile.getAbsolutePath() + "/" + VitaminBomManager.getManufacturingBomJson());
 				if (bom.exists()) {
 					File file = new File(
-							baseWorkspaceFile.getAbsolutePath() + "/" + VitaminBomManager.getManufacturingBomJson());
+							target.getAbsolutePath() + "/" + VitaminBomManager.getManufacturingBomJson());
 //					if (file.exists())
 //						file.delete();
 					try {
@@ -503,7 +502,7 @@ public class BowlerKernel {
 			else {
 				com.neuronrobotics.sdk.common.Log.error("Exporting files without print bed");
 			}
-			new CadFileExporter().generateManufacturingParts(csgBits, baseWorkspaceFile);
+			new CadFileExporter().generateManufacturingParts(csgBits, target);
 		} catch (Throwable t) {
 			Log.error(t);
 			fail();

--- a/src/main/java/com/neuronrobotics/bowlerstudio/scripting/GroovyHelper.java
+++ b/src/main/java/com/neuronrobotics/bowlerstudio/scripting/GroovyHelper.java
@@ -70,6 +70,10 @@ public class GroovyHelper implements IScriptingLanguage, IScriptingLanguageDebug
 			code=code.replace("inlineScriptRun(", "inlineScriptRun(csgdb,");
 			code=code.replace("inlineScriptStringRun(", "inlineScriptStringRun(csgdb,");
 			code=code.replace("gitScriptRun(", "gitScriptRun(((eu.mihosoft.vrl.v3d.parametrics.CSGDatabaseInstance)csgdb),");
+			//getVitaminsDisplay(
+			code=code.replace("getVitaminsDisplay(", "getVitaminsDisplay(csgdb,");
+			code=code.replace("getVitamins(", "getVitamins(csgdb,");
+
 		}
 		
 		Script script;


### PR DESCRIPTION
close #54 

Some time in april a change in the JCSG sources combined with a change from 22.04 to 24.04 ubuntu caused the tests to hang indefinably until killed. 

the changes in JCSG make the hanging bug go away by adding a timeout to the Image thumbnail creation thread. 

Adding additional changes to the kernel and groovy script layer we needed to catch bugs that had been missed by the CI not running. 

