### PR TITLE
Solve cursor movement on custom workplane sometimes not working

### DIFF
--- a/src/main/java/com/neuronrobotics/bowlerstudio/scripting/cadoodle/MoveCenter.java
+++ b/src/main/java/com/neuronrobotics/bowlerstudio/scripting/cadoodle/MoveCenter.java
@@ -118,14 +118,19 @@ public class MoveCenter extends CaDoodleOperation {
 	}
 
 	public boolean isWorkplaneNotOrigin(TransformNR w) {
+
 		double epsilon = 0.00001;
-		RotationNR r = w.getRotation();
+
+		// Check for any translation
 		double abst = Math.abs(w.getX());
 		double abs2t = Math.abs(w.getY());
 		double abs3t = Math.abs(w.getZ());
 
 		if ((abst > epsilon) || (abs2t > epsilon) || (abs3t > epsilon))
 			return true;
+
+		// Check for any rotation
+		RotationNR r = w.getRotation();
 
 		double abs = Math.abs(r.getRotationAzimuthDegrees());
 		double abs2 = Math.abs(r.getRotationElevationDegrees());
@@ -139,10 +144,12 @@ public class MoveCenter extends CaDoodleOperation {
 	}
 
 	public MoveCenter setLocation(TransformNR location) throws InvalidLocationMove {
-		if (isWorkplaneNotOrigin(location))
+
+//		if (isWorkplaneNotOrigin(location))
 			this.location = location;
-		else
-			throw new InvalidLocationMove();
+//		else
+//			throw new InvalidLocationMove();
+
 		return this;
 	}
 


### PR DESCRIPTION
**=== REVIEW BEFORE MERGE===**

Solve cursor movement not working.

Sometimes the object doesn't move on a custom work plane when the cursor keys are pressed, then this exception is thrown:
Error com.neuronrobotics.sdk.common.Log:error:
```
  [16:29:19.706] com.neuronrobotics.bowlerstudio.scripting.cadoodle.InvalidLocationMove
        at com.neuronrobotics.bowlerstudio.scripting.cadoodle.MoveCenter.setLocation(MoveCenter.java:157)
        at com.commonwealthrobotics.controls.SelectionSession.lambda$moveInCameraFrame$49(SelectionSession.java:1961)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)
```

It is thrown here:
	public MoveCenter setLocation(TransformNR location) throws InvalidLocationMove {

		if (isWorkplaneNotOrigin(location))
			this.location = location;
		else {
			throw new InvalidLocationMove();
		}
		return this;
	}

I am not sure why isWorkplaneNotOrigin is required here. The provided "location" seems to be the object location relative to the custom work plane. In "location" no rotation is present, and the object "translation" is relative to the custom work plane. That means that when object goes through the origin the exception is thrown and the object does not move.
Here is the data that "location" holds:
```
{ 001.00,       000.00, 000.00, 000.00   },
{ 000.00,       001.00, 000.00, 000.00   },
{ 000.00,       000.00, 001.00, 000.00   },
{ 000.00,       000.00, 000.00, 001.00   }
Quaturnion: W=1.0, x=-0.0, y=-0.0, z=-0.0
Rotation angle (degrees): az= 0.0, elev= -0.0, tilt=0.0

```
This PR removes the requirement of "isWorkplaneNotOrigin" for saving the new object location.

